### PR TITLE
fix: Update_github_actions_libraries INFRA-106

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -11,9 +11,9 @@ jobs:
       GOLANG_VERSION: "1.17.7"
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -18,16 +18,16 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-cache
         with:
           path: node_modules
@@ -37,7 +37,7 @@ jobs:
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 


### PR DESCRIPTION
## Update GitHub actions libraries:
- actions/checkout: Upgraded library from 2 to 3, [to upgrade to NodeJS 16 requires version 3.0.0 or higher.](https://github.com/actions/checkout/releases)
- actions/setup-node: Upgraded library from 1 to 3, [to upgrade to NodeJS 16 requires version 3.0.0 or higher.](https://github.com/Azure/setup-helm/releases)
- actions/cache: Upgraded library from 2 to 3, [to upgrade to NodeJS 16 requires version 3.0.0 or higher.](https://github.com/actions/cache/releases?page=2)
- actions/setup-go: Upgraded library from 2 to 3, [to upgrade to NodeJS 16 is required version 3.0 or higher.](https://github.com/actions/setup-go/releases)
